### PR TITLE
fix: Have the consumer variable in scope to avoid dropping active connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .set_queue_manager()
         .build()
         .unwrap()
-        .set_event_callback(new_event, new_callback)
+        .set_event_callback(new_event, new_callback);
+    
+    //Have the consumer running and in scope, otherwise It'll drop active connections.
+    consumer
         .start_consumer()
         .await?;
+        
 }
 ````
 The following code, will create the queues on a rabbitMQ node, no_ack.

--- a/alicemq/src/callback.rs
+++ b/alicemq/src/callback.rs
@@ -1,4 +1,3 @@
-use std::str;
 use amqprs::channel::{BasicAckArguments, Channel};
 use amqprs::consumer::AsyncConsumer;
 use amqprs::{BasicProperties, Deliver};

--- a/alicemq/src/consumer.rs
+++ b/alicemq/src/consumer.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use amqprs::callbacks::{DefaultChannelCallback, DefaultConnectionCallback};
 use amqprs::channel::{BasicConsumeArguments, Channel, QueueBindArguments, QueueDeclareArguments};
 use tracing_subscriber::FmtSubscriber;
-use tracing::{info, Level, trace};
+use tracing::{info, Level};
 
 use crate::constants::{ROUTING_KEY, EXCHANGE_NAME};
 use crate::{callback::*, connection_arguments::*};
@@ -64,13 +64,12 @@ impl Consumer {
         );
         self
     }
-    pub async fn start_consumer(mut self) -> Result<Self, Box<dyn Error>> {
+    pub async fn start_consumer(&mut self) -> Result<(), Box<dyn Error>> {
         let subscriber = FmtSubscriber::builder()
             .with_max_level(Level::TRACE)
             .finish();
         tracing::subscriber::set_global_default(subscriber)
             .expect("setting default subscriber failed");
-        //had to clone the queue manager, after it's borrowed it drops all connections.
         let queue_manager = self.queue_manager.clone();
         for (event, callback_handler) in queue_manager {
             let channel = self.connection
@@ -109,6 +108,6 @@ impl Consumer {
             let _ = &self.registered_channels.push(channel);
             info!("Started consumer ...");
         }
-        Ok(self)
+        Ok(())
     }
 }

--- a/alicemq/src/publisher.rs
+++ b/alicemq/src/publisher.rs
@@ -39,6 +39,10 @@ impl Publisher {
         time::sleep(time::Duration::from_millis(100)).await;
         info!("message sent with data: {:?}", data);
     }
+
+    pub async fn close(self) {
+        self.connection.close();
+    }
 }
 
 #[derive(Default)]

--- a/examples/src/basic_consume_publish.rs
+++ b/examples/src/basic_consume_publish.rs
@@ -10,22 +10,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //TODO: Add tracing for publishing messages instead of prints.
     let new_event = "test_event".to_string();
     let new_callback = BaseCallbackConsumer::new(false);
-    let consumer = Consumer::new()
+    let mut consumer = Consumer::new()
         .connect()
         .await?
         .set_queue_manager()
         .build()
         .unwrap()
-        .set_event_callback(new_event, new_callback)
+        .set_event_callback(new_event, new_callback);
+
+    /*Starts the consumer, and keep it running, if out scope closes active connections.*/
+    consumer
         .start_consumer()
         .await?;
 
     let data = "{data: value}";
 
-    //Giving time to bind queues to the consumer.
-    time::sleep(time::Duration::from_secs(10)).await;
+    time::sleep(time::Duration::from_secs(5)).await;
 
-    let publisher = Publisher::new()
+    let mut publisher = Publisher::new()
         .connect()
         .await.unwrap()
         .build()
@@ -34,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for _ in 1 .. 10 {
         publisher.clone().send_message("test_event".to_string(), data.to_string()).await;
     }
+    publisher.close().await;
     let guard = Notify::new();
     guard.notified().await;
     Ok(())


### PR DESCRIPTION
In the main example, added a specific call to the consumer variable to avoid it from being dropped, when out of scope. Removed unused imports, and on starting the consumer added a call to mutable self, and passed no_ack arguments from the base callback.